### PR TITLE
Updated `copycat` to `0.2.1`

### DIFF
--- a/Formula/copycat.rb
+++ b/Formula/copycat.rb
@@ -1,22 +1,22 @@
 class Copycat < Formula
   desc "CLI to copy project source code as Markdown to clipboard for LLMs"
   homepage "https://github.com/rhajizada/copycat"
-  version "0.2.0"
+  version "0.2.1"
   license "MIT"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://github.com/rhajizada/copycat/releases/download/v0.2.0/copycat-x86_64-apple-darwin.tar.gz"
-    sha256 "5f41303343bbd9bd54d23df2118df86507605526d30034d276c7e135ddf88e46"
+    url "https://github.com/rhajizada/copycat/releases/download/v#{version}/copycat-x86_64-apple-darwin.tar.gz"
+    sha256 "e9c9ecffefb701d7f582b08222b53fbef6838ccfe099d05fe989545e966097ec"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://github.com/rhajizada/copycat/releases/download/v0.2.0/copycat-aarch64-apple-darwin.tar.gz"
-      sha256 "9e5bdce56fc6ef76595241529dba5dbd7de184d7724133dba1dc53c9c73f74d4"
+    url "https://github.com/rhajizada/copycat/releases/download/v#{version}/copycat-aarch64-apple-darwin.tar.gz"
+    sha256 "2b690914a1bbb68a98183a710ba2311d2f2f3ff3be4b0fece4a38259b3d59bd5"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://github.com/rhajizada/copycat/releases/download/v0.2.0/copycat-x86_64-unknown-linux-gnu.tar.gz"
-    sha256 "75a21808868c985534b3bd1f5af3495e15a15173c7fc966a8d3b3b5076985025"
+    url "https://github.com/rhajizada/copycat/releases/download/v#{version}/copycat-x86_64-unknown-linux-gnu.tar.gz"
+    sha256 "a74efa364c318fb980f7c70c79cf196d55f529dc3ac363337949d43e53da83b0"
   end
 
   def install

--- a/Formula/donezo.rb
+++ b/Formula/donezo.rb
@@ -5,17 +5,17 @@ class Donezo < Formula
   license "MIT"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://github.com/rhajizada/donezo/releases/download/v0.1.0/donezo-darwin-amd64.tar.gz"
+    url "https://github.com/rhajizada/donezo/releases/download/v#{version}/donezo-darwin-amd64.tar.gz"
     sha256 "7343b970c05bde06b984c73d48e30b972a9d930ec1fe43584abe88c9dacdecde"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://github.com/rhajizada/donezo/releases/download/v0.1.0/donezo-darwin-arm64.tar.gz"
+    url "https://github.com/rhajizada/donezo/releases/download/v#{version}/donezo-darwin-arm64.tar.gz"
     sha256 "0b8d26077994da39389a7c1491d0b3a011e3469c078cb32d6ff99a26f82a9869"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://github.com/rhajizada/donezo/releases/download/v0.1.0/donezo-linux-amd64.tar.gz"
+    url "https://github.com/rhajizada/donezo/releases/download/v#{version}/donezo-linux-amd64.tar.gz"
     sha256 "65ffd54223d07f75105be054aac44c745c9abd098525904230862fbc84c86c30"
   end
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Package manager for macOS (or Linux), see more at <https://brew.sh>
 
 | Formula     | Description                                                                                               | Repository                             |
 | :---------- | :-------------------------------------------------------------------------------------------------------- | :------------------------------------- |
-| **donezo**  | Simple TUI to-do app written in Go using Bubble Tea and SQLite.                                           | <https://github.com/rhajizada/donezo>  |
 | **copycat** | CLI tool to copy your project source code as Markdown to clipboard for context-aware responses from LLMs. | <https://github.com/rhajizada/copycat> |
+| **donezo**  | Simple TUI to-do app written in Go using Bubble Tea and SQLite.                                           | <https://github.com/rhajizada/donezo>  |
 
 ## How do I install these formulae?
 


### PR DESCRIPTION
## Description
- Updated existing formulas to use defined version instead of harcoded ones for URLs
- Updated `copycat` to `0.2.1`
- Alphabetically listing formulas in `README.md`